### PR TITLE
Implement more number theory functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,8 +23,9 @@ extern crate num_traits as traits;
 
 use core::mem;
 use core::ops::Add;
+use core::cmp::Ordering;
 
-use traits::{Num, Signed, Zero};
+use traits::{Num, NumRef, RefNum, Signed, Zero};
 
 mod roots;
 pub use roots::Roots;
@@ -1013,6 +1014,57 @@ impl_integer_for_usize!(usize, test_integer_usize);
 #[cfg(has_i128)]
 impl_integer_for_usize!(u128, test_integer_u128);
 
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct GcdResult<T> {
+    /// Greatest common divisor.
+    pub gcd: T,
+    /// Coefficients such that: gcd(a, b) = c1*a + c2*b
+    pub c1: T, pub c2: T,
+}
+
+/// Calculate greatest common divisor and the corresponding coefficients.
+pub fn extended_gcd<T: Integer + NumRef>(a: T, b: T) -> GcdResult<T>
+    where for<'a> &'a T: RefNum<T>
+{
+    // Euclid's extended algorithm
+    let (mut s, mut old_s) = (T::zero(), T::one());
+    let (mut t, mut old_t) = (T::one(), T::zero());
+    let (mut r, mut old_r) = (b, a);
+
+    while r != T::zero() {
+        let quotient = &old_r / &r;
+        old_r = old_r - &quotient * &r; std::mem::swap(&mut old_r, &mut r);
+        old_s = old_s - &quotient * &s; std::mem::swap(&mut old_s, &mut s);
+        old_t = old_t - quotient * &t; std::mem::swap(&mut old_t, &mut t);
+    }
+
+    let _quotients = (t, s); // == (a, b) / gcd
+
+    GcdResult { gcd: old_r, c1: old_s, c2: old_t }
+}
+
+/// Find the standard representation of a (mod n).
+pub fn normalize<T: Integer + NumRef>(a: T, n: &T) -> T {
+    let a = a % n;
+    match a.cmp(&T::zero()) {
+        Ordering::Less => a + n,
+        _ => a,
+    }
+}
+
+/// Calculate the inverse of a (mod n).
+pub fn inverse<T: Integer + NumRef + Clone>(a: T, n: &T) -> Option<T>
+    where for<'a> &'a T: RefNum<T>
+{
+    let GcdResult { gcd, c1: c, .. } = extended_gcd(a, n.clone());
+    if gcd == T::one() {
+        Some(normalize(c, n))
+    } else {
+        None
+    }
+}
+
+
 /// An iterator over binomial coefficients.
 pub struct IterBinomial<T> {
     a: T,
@@ -1167,6 +1219,24 @@ fn test_lcm_overflow() {
     check!(u32, 0x8000_0000, 0x02, 0x8000_0000);
     check!(i64, 0x4000_0000_0000_0000, 0x04, 0x4000_0000_0000_0000);
     check!(u64, 0x8000_0000_0000_0000, 0x02, 0x8000_0000_0000_0000);
+}
+
+#[test]
+fn test_extended_gcd() {
+    assert_eq!(extended_gcd(240, 46), GcdResult { gcd: 2, c1: -9, c2: 47});
+}
+
+#[test]
+fn test_normalize() {
+    assert_eq!(normalize(10, &7), 3);
+    assert_eq!(normalize(7, &7), 0);
+    assert_eq!(normalize(5, &7), 5);
+    assert_eq!(normalize(-3, &7), 4);
+}
+
+#[test]
+fn test_inverse() {
+    assert_eq!(inverse(5, &7).unwrap(), 3);
 }
 
 #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,9 +21,9 @@ extern crate std;
 
 extern crate num_traits as traits;
 
+use core::cmp::Ordering;
 use core::mem;
 use core::ops::{Add, Neg, Shr};
-use core::cmp::Ordering;
 
 use traits::{Num, NumRef, RefNum, Signed, Zero};
 
@@ -1019,14 +1019,16 @@ pub struct GcdResult<T> {
     /// Greatest common divisor.
     pub gcd: T,
     /// Coefficients such that: gcd(a, b) = c1*a + c2*b
-    pub c1: T, pub c2: T,
+    pub c1: T,
+    pub c2: T,
     /// Dummy field to make sure adding new fields is not a breaking change.
     seal: (),
 }
 
 /// Calculate greatest common divisor and the corresponding coefficients.
 pub fn extended_gcd<T: Integer + NumRef>(a: T, b: T) -> GcdResult<T>
-    where for<'a> &'a T: RefNum<T>
+where
+    for<'a> &'a T: RefNum<T>,
 {
     // Euclid's extended algorithm
     let (mut s, mut old_s) = (T::zero(), T::one());
@@ -1035,14 +1037,22 @@ pub fn extended_gcd<T: Integer + NumRef>(a: T, b: T) -> GcdResult<T>
 
     while r != T::zero() {
         let quotient = &old_r / &r;
-        old_r = old_r - &quotient * &r; mem::swap(&mut old_r, &mut r);
-        old_s = old_s - &quotient * &s; mem::swap(&mut old_s, &mut s);
-        old_t = old_t - quotient * &t; mem::swap(&mut old_t, &mut t);
+        old_r = old_r - &quotient * &r;
+        mem::swap(&mut old_r, &mut r);
+        old_s = old_s - &quotient * &s;
+        mem::swap(&mut old_s, &mut s);
+        old_t = old_t - quotient * &t;
+        mem::swap(&mut old_t, &mut t);
     }
 
     let _quotients = (t, s); // == (a, b) / gcd
 
-    GcdResult { gcd: old_r, c1: old_s, c2: old_t, seal: () }
+    GcdResult {
+        gcd: old_r,
+        c1: old_s,
+        c2: old_t,
+        seal: (),
+    }
 }
 
 /// Find the standard representation of a (mod n).
@@ -1056,7 +1066,8 @@ pub fn normalize<T: Integer + NumRef>(a: T, n: &T) -> T {
 
 /// Calculate the inverse of a (mod n).
 pub fn inverse<T: Integer + NumRef + Clone>(a: T, n: &T) -> Option<T>
-    where for<'a> &'a T: RefNum<T>
+where
+    for<'a> &'a T: RefNum<T>,
 {
     let GcdResult { gcd, c1: c, .. } = extended_gcd(a, n.clone());
     if gcd == T::one() {
@@ -1068,8 +1079,9 @@ pub fn inverse<T: Integer + NumRef + Clone>(a: T, n: &T) -> Option<T>
 
 /// Calculate base^exp (mod modulus).
 pub fn powm<T>(base: &T, exp: &T, modulus: &T) -> T
-    where T: Integer + NumRef + Clone + Neg<Output = T> + Shr<i32, Output = T>,
-          for<'a> &'a T: RefNum<T>
+where
+    T: Integer + NumRef + Clone + Neg<Output = T> + Shr<i32, Output = T>,
+    for<'a> &'a T: RefNum<T>,
 {
     let zero = T::zero();
     let one = T::one();
@@ -1249,7 +1261,15 @@ fn test_lcm_overflow() {
 
 #[test]
 fn test_extended_gcd() {
-    assert_eq!(extended_gcd(240, 46), GcdResult { gcd: 2, c1: -9, c2: 47, seal: () });
+    assert_eq!(
+        extended_gcd(240, 46),
+        GcdResult {
+            gcd: 2,
+            c1: -9,
+            c2: 47,
+            seal: ()
+        }
+    );
 }
 
 #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1020,6 +1020,8 @@ pub struct GcdResult<T> {
     pub gcd: T,
     /// Coefficients such that: gcd(a, b) = c1*a + c2*b
     pub c1: T, pub c2: T,
+    /// Dummy field to make sure adding new fields is not a breaking change.
+    seal: (),
 }
 
 /// Calculate greatest common divisor and the corresponding coefficients.
@@ -1040,7 +1042,7 @@ pub fn extended_gcd<T: Integer + NumRef>(a: T, b: T) -> GcdResult<T>
 
     let _quotients = (t, s); // == (a, b) / gcd
 
-    GcdResult { gcd: old_r, c1: old_s, c2: old_t }
+    GcdResult { gcd: old_r, c1: old_s, c2: old_t, seal: () }
 }
 
 /// Find the standard representation of a (mod n).
@@ -1247,7 +1249,7 @@ fn test_lcm_overflow() {
 
 #[test]
 fn test_extended_gcd() {
-    assert_eq!(extended_gcd(240, 46), GcdResult { gcd: 2, c1: -9, c2: 47});
+    assert_eq!(extended_gcd(240, 46), GcdResult { gcd: 2, c1: -9, c2: 47, seal: () });
 }
 
 #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1033,9 +1033,9 @@ pub fn extended_gcd<T: Integer + NumRef>(a: T, b: T) -> GcdResult<T>
 
     while r != T::zero() {
         let quotient = &old_r / &r;
-        old_r = old_r - &quotient * &r; std::mem::swap(&mut old_r, &mut r);
-        old_s = old_s - &quotient * &s; std::mem::swap(&mut old_s, &mut s);
-        old_t = old_t - quotient * &t; std::mem::swap(&mut old_t, &mut t);
+        old_r = old_r - &quotient * &r; mem::swap(&mut old_r, &mut r);
+        old_s = old_s - &quotient * &s; mem::swap(&mut old_s, &mut s);
+        old_t = old_t - quotient * &t; mem::swap(&mut old_t, &mut t);
     }
 
     let _quotients = (t, s); // == (a, b) / gcd

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1014,19 +1014,8 @@ impl_integer_for_usize!(usize, test_integer_usize);
 #[cfg(has_i128)]
 impl_integer_for_usize!(u128, test_integer_u128);
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub struct GcdResult<T> {
-    /// Greatest common divisor.
-    pub gcd: T,
-    /// Coefficients such that: gcd(a, b) = c1*a + c2*b
-    pub c1: T,
-    pub c2: T,
-    /// Dummy field to make sure adding new fields is not a breaking change.
-    seal: (),
-}
-
 /// Calculate greatest common divisor and the corresponding coefficients.
-pub fn extended_gcd<T: Integer + NumRef>(a: T, b: T) -> GcdResult<T>
+pub fn extended_gcd<T: Integer + NumRef>(a: T, b: T) -> ExtendedGcd<T>
 where
     for<'a> &'a T: RefNum<T>,
 {
@@ -1047,11 +1036,11 @@ where
 
     let _quotients = (t, s); // == (a, b) / gcd
 
-    GcdResult {
+    ExtendedGcd {
         gcd: old_r,
-        c1: old_s,
-        c2: old_t,
-        seal: (),
+        x: old_s,
+        y: old_t,
+        _hidden: (),
     }
 }
 
@@ -1069,7 +1058,7 @@ pub fn inverse<T: Integer + NumRef + Clone>(a: T, n: &T) -> Option<T>
 where
     for<'a> &'a T: RefNum<T>,
 {
-    let GcdResult { gcd, c1: c, .. } = extended_gcd(a, n.clone());
+    let ExtendedGcd { gcd, x: c, .. } = extended_gcd(a, n.clone());
     if gcd == T::one() {
         Some(normalize(c, n))
     } else {
@@ -1263,11 +1252,11 @@ fn test_lcm_overflow() {
 fn test_extended_gcd() {
     assert_eq!(
         extended_gcd(240, 46),
-        GcdResult {
+        ExtendedGcd {
             gcd: 2,
-            c1: -9,
-            c2: 47,
-            seal: ()
+            x: -9,
+            y: 47,
+            _hidden: ()
         }
     );
 }


### PR DESCRIPTION
This implements the extended Euclidean algorithm, the modular inverse and modular exponentiation.

* This is taken from https://github.com/vks/discrete-log and uses the traits from `num-traits`.
* To avoid break backwards compatibility, everything was added as a free function. However, for example `powm` should be part of a trait, because bigint libraries can implement it more efficiently.
* The trait requirements for `powm` are not pretty, because the existing traits were not enough.

Fixes #3.