### PR TITLE
Define ceiled division, rounding to nearest multiple

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,10 +199,14 @@ pub trait Integer: Sized + Num + PartialOrd + Ord + Eq {
     ///
     /// ~~~
     /// # use num_integer::Integer;
-    /// assert_eq!(16.next_multiple_of(& 8), 16);
-    /// assert_eq!(23.next_multiple_of(& 8), 24);
-    /// assert_eq!(16.next_multiple_of(&-8), 16);
-    /// assert_eq!(23.next_multiple_of(&-8), 16);
+    /// assert_eq!(( 16).next_multiple_of(& 8),  16);
+    /// assert_eq!(( 23).next_multiple_of(& 8),  24);
+    /// assert_eq!(( 16).next_multiple_of(&-8),  16);
+    /// assert_eq!(( 23).next_multiple_of(&-8),  16);
+    /// assert_eq!((-16).next_multiple_of(& 8), -16);
+    /// assert_eq!((-23).next_multiple_of(& 8), -16);
+    /// assert_eq!((-16).next_multiple_of(&-8), -16);
+    /// assert_eq!((-23).next_multiple_of(&-8), -24);
     /// ~~~
     #[inline]
     fn next_multiple_of(&self, other: &Self) -> Self where Self: Clone {
@@ -216,13 +220,17 @@ pub trait Integer: Sized + Num + PartialOrd + Ord + Eq {
     ///
     /// ~~~
     /// # use num_integer::Integer;
-    /// assert_eq!(16.next_multiple_back_of(& 8), 16);
-    /// assert_eq!(23.next_multiple_back_of(& 8), 16);
-    /// assert_eq!(16.next_multiple_back_of(&-8), 16);
-    /// assert_eq!(23.next_multiple_back_of(&-8), 24);
+    /// assert_eq!(( 16).prev_multiple_of(& 8),  16);
+    /// assert_eq!(( 23).prev_multiple_of(& 8),  16);
+    /// assert_eq!(( 16).prev_multiple_of(&-8),  16);
+    /// assert_eq!(( 23).prev_multiple_of(&-8),  24);
+    /// assert_eq!((-16).prev_multiple_of(& 8), -16);
+    /// assert_eq!((-23).prev_multiple_of(& 8), -24);
+    /// assert_eq!((-16).prev_multiple_of(&-8), -16);
+    /// assert_eq!((-23).prev_multiple_of(&-8), -16);
     /// ~~~
     #[inline]
-    fn next_multiple_back_of(&self, other: &Self) -> Self where Self: Clone {
+    fn prev_multiple_of(&self, other: &Self) -> Self where Self: Clone {
         self.clone() - self.mod_floor(other)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,7 +204,8 @@ pub trait Integer: Sized + Num + PartialOrd + Ord + Eq {
     /// ~~~
     #[inline]
     fn next_multiple_of(&self, other: &Self) -> Self where Self: Clone {
-        self.div_ceil(other).mul(other.clone())
+        let m = self.mod_floor(other);
+        self.clone() + if m.is_zero() { Self::zero() } else { other.clone() - m }
     }
 
     /// Rounds down to nearest multiple of argument.
@@ -218,7 +219,7 @@ pub trait Integer: Sized + Num + PartialOrd + Ord + Eq {
     /// ~~~
     #[inline]
     fn next_multiple_back_of(&self, other: &Self) -> Self where Self: Clone {
-        self.div_floor(other).mul(other.clone())
+        self.clone() - self.mod_floor(other)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,11 +199,11 @@ pub trait Integer: Sized + Num + PartialOrd + Ord + Eq {
     ///
     /// ~~~
     /// # use num_integer::Integer;
-    /// assert_eq!(16.round_up_to(&8), 16);
-    /// assert_eq!(23.round_up_to(&8), 24);
+    /// assert_eq!(16.next_multiple_of(&8), 16);
+    /// assert_eq!(23.next_multiple_of(&8), 24);
     /// ~~~
     #[inline]
-    fn round_up_to(&self, other: &Self) -> Self where Self: traits::NumRef {
+    fn next_multiple_of(&self, other: &Self) -> Self where Self: traits::NumRef {
         self.div_ceil(other).mul(other)
     }
 
@@ -213,11 +213,11 @@ pub trait Integer: Sized + Num + PartialOrd + Ord + Eq {
     ///
     /// ~~~
     /// # use num_integer::Integer;
-    /// assert_eq!(16.round_down_to(&8), 16);
-    /// assert_eq!(23.round_down_to(&8), 16);
+    /// assert_eq!(16.next_multiple_back_of(&8), 16);
+    /// assert_eq!(23.next_multiple_back_of(&8), 16);
     /// ~~~
     #[inline]
-    fn round_down_to(&self, other: &Self) -> Self where Self: traits::NumRef {
+    fn next_multiple_back_of(&self, other: &Self) -> Self where Self: traits::NumRef {
         self.div_floor(other).mul(other)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,11 @@ pub trait Integer: Sized + Num + PartialOrd + Ord + Eq {
     /// ~~~
     fn div_ceil(&self, other: &Self) -> Self {
         let (q, r) = self.div_mod_floor(other);
-        if r.is_zero() { q } else { q+Self::one() }
+        if r.is_zero() {
+            q
+        } else {
+            q + Self::one()
+        }
     }
 
     /// Greatest Common Divisor (GCD).
@@ -213,9 +217,17 @@ pub trait Integer: Sized + Num + PartialOrd + Ord + Eq {
     /// assert_eq!((-23).next_multiple_of(&-8), -24);
     /// ~~~
     #[inline]
-    fn next_multiple_of(&self, other: &Self) -> Self where Self: Clone {
+    fn next_multiple_of(&self, other: &Self) -> Self
+    where
+        Self: Clone,
+    {
         let m = self.mod_floor(other);
-        self.clone() + if m.is_zero() { Self::zero() } else { other.clone() - m }
+        self.clone()
+            + if m.is_zero() {
+                Self::zero()
+            } else {
+                other.clone() - m
+            }
     }
 
     /// Rounds down to nearest multiple of argument.
@@ -238,7 +250,10 @@ pub trait Integer: Sized + Num + PartialOrd + Ord + Eq {
     /// assert_eq!((-23).prev_multiple_of(&-8), -16);
     /// ~~~
     #[inline]
-    fn prev_multiple_of(&self, other: &Self) -> Self where Self: Clone {
+    fn prev_multiple_of(&self, other: &Self) -> Self
+    where
+        Self: Clone,
+    {
         self.clone() - self.mod_floor(other)
     }
 }
@@ -322,10 +337,11 @@ macro_rules! impl_integer_for_isize {
 
             #[inline]
             fn div_ceil(&self, other: &Self) -> Self {
-                match self.div_rem(other) {
-                    (d, r) if (r > 0 && *other > 0)
-                           || (r < 0 && *other < 0) => d + 1,
-                    (d, _)                          => d,
+                let (d, r) = self.div_rem(other);
+                if (r > 0 && *other > 0) || (r < 0 && *other < 0) {
+                    d + 1
+                } else {
+                    d
                 }
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,6 +195,10 @@ pub trait Integer: Sized + Num + PartialOrd + Ord + Eq {
 
     /// Rounds up to nearest multiple of argument.
     ///
+    /// # Notes
+    ///
+    /// For signed types, `a.next_multiple_of(b) = a.prev_multiple_of(b.neg())`.
+    ///
     /// # Examples
     ///
     /// ~~~
@@ -215,6 +219,10 @@ pub trait Integer: Sized + Num + PartialOrd + Ord + Eq {
     }
 
     /// Rounds down to nearest multiple of argument.
+    ///
+    /// # Notes
+    ///
+    /// For signed types, `a.prev_multiple_of(b) = a.next_multiple_of(b.neg())`.
     ///
     /// # Examples
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,8 +203,8 @@ pub trait Integer: Sized + Num + PartialOrd + Ord + Eq {
     /// assert_eq!(23.next_multiple_of(&8), 24);
     /// ~~~
     #[inline]
-    fn next_multiple_of(&self, other: &Self) -> Self where Self: traits::NumRef {
-        self.div_ceil(other).mul(other)
+    fn next_multiple_of(&self, other: &Self) -> Self where Self: Clone {
+        self.div_ceil(other).mul(other.clone())
     }
 
     /// Rounds down to nearest multiple of argument.
@@ -217,8 +217,8 @@ pub trait Integer: Sized + Num + PartialOrd + Ord + Eq {
     /// assert_eq!(23.next_multiple_back_of(&8), 16);
     /// ~~~
     #[inline]
-    fn next_multiple_back_of(&self, other: &Self) -> Self where Self: traits::NumRef {
-        self.div_floor(other).mul(other)
+    fn next_multiple_back_of(&self, other: &Self) -> Self where Self: Clone {
+        self.div_floor(other).mul(other.clone())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,8 +199,10 @@ pub trait Integer: Sized + Num + PartialOrd + Ord + Eq {
     ///
     /// ~~~
     /// # use num_integer::Integer;
-    /// assert_eq!(16.next_multiple_of(&8), 16);
-    /// assert_eq!(23.next_multiple_of(&8), 24);
+    /// assert_eq!(16.next_multiple_of(& 8), 16);
+    /// assert_eq!(23.next_multiple_of(& 8), 24);
+    /// assert_eq!(16.next_multiple_of(&-8), 16);
+    /// assert_eq!(23.next_multiple_of(&-8), 16);
     /// ~~~
     #[inline]
     fn next_multiple_of(&self, other: &Self) -> Self where Self: Clone {
@@ -214,8 +216,10 @@ pub trait Integer: Sized + Num + PartialOrd + Ord + Eq {
     ///
     /// ~~~
     /// # use num_integer::Integer;
-    /// assert_eq!(16.next_multiple_back_of(&8), 16);
-    /// assert_eq!(23.next_multiple_back_of(&8), 16);
+    /// assert_eq!(16.next_multiple_back_of(& 8), 16);
+    /// assert_eq!(23.next_multiple_back_of(& 8), 16);
+    /// assert_eq!(16.next_multiple_back_of(&-8), 16);
+    /// assert_eq!(23.next_multiple_back_of(&-8), 24);
     /// ~~~
     #[inline]
     fn next_multiple_back_of(&self, other: &Self) -> Self where Self: Clone {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,10 @@ pub trait Integer: Sized + Num + PartialOrd + Ord + Eq {
     /// assert_eq!((-1).div_ceil( &2), 0);
     /// assert_eq!((-1).div_ceil(&-2), 1);
     /// ~~~
-    fn div_ceil(&self, other: &Self) -> Self;
+    fn div_ceil(&self, other: &Self) -> Self {
+        let (q, r) = self.div_mod_floor(other);
+        if r.is_zero() { q } else { q+Self::one() }
+    }
 
     /// Greatest Common Divisor (GCD).
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,6 +199,7 @@ pub trait Integer: Sized + Num + PartialOrd + Ord + Eq {
     /// assert_eq!(16.round_up_to(&8), 16);
     /// assert_eq!(23.round_up_to(&8), 24);
     /// ~~~
+    #[inline]
     fn round_up_to(&self, other: &Self) -> Self where Self: traits::NumRef {
         self.div_ceil(other).mul(other)
     }
@@ -212,6 +213,7 @@ pub trait Integer: Sized + Num + PartialOrd + Ord + Eq {
     /// assert_eq!(16.round_down_to(&8), 16);
     /// assert_eq!(23.round_down_to(&8), 16);
     /// ~~~
+    #[inline]
     fn round_down_to(&self, other: &Self) -> Self where Self: traits::NumRef {
         self.div_floor(other).mul(other)
     }


### PR DESCRIPTION
I often find `round_up_to` in particular useful; `round_down_to` is also defined for completeness.

`div_ceil` is also defined as `round_up_to` is defined in terms of it.
