### PR TITLE
Mark Integer::divides as deprecated.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,7 +202,10 @@ pub trait Integer: Sized + Num + PartialOrd + Ord + Eq {
 
     /// Deprecated, use `is_multiple_of` instead.
     #[deprecated(note = "Please use is_multiple_of instead")]
-    fn divides(&self, other: &Self) -> bool;
+    #[inline]
+    fn divides(&self, other: &Self) -> bool {
+        self.is_multiple_of(other)
+    }
 
     /// Returns `true` if `self` is a multiple of `other`.
     ///
@@ -524,12 +527,6 @@ macro_rules! impl_integer_for_isize {
                 // should not have to recalculate abs
                 let lcm = (*self * (*other / gcd)).abs();
                 (gcd, lcm)
-            }
-
-            /// Deprecated, use `is_multiple_of` instead.
-            #[inline]
-            fn divides(&self, other: &Self) -> bool {
-                self.is_multiple_of(other)
             }
 
             /// Returns `true` if the number is a multiple of `other`.
@@ -891,12 +888,6 @@ macro_rules! impl_integer_for_usize {
                 let gcd = self.gcd(other);
                 let lcm = *self * (*other / gcd);
                 (gcd, lcm)
-            }
-
-            /// Deprecated, use `is_multiple_of` instead.
-            #[inline]
-            fn divides(&self, other: &Self) -> bool {
-                self.is_multiple_of(other)
             }
 
             /// Returns `true` if the number is a multiple of `other`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,6 +201,7 @@ pub trait Integer: Sized + Num + PartialOrd + Ord + Eq {
     }
 
     /// Deprecated, use `is_multiple_of` instead.
+    #[deprecated(note = "Please use is_multiple_of instead")]
     fn divides(&self, other: &Self) -> bool;
 
     /// Returns `true` if `self` is a multiple of `other`.


### PR DESCRIPTION
Resolves #41.
