### PR TITLE
Fix test fallout from unstable int_roundings

### DIFF
--- a/benches/average.rs
+++ b/benches/average.rs
@@ -53,28 +53,28 @@ macro_rules! naive_average {
         impl super::NaiveAverage for $T {
             fn naive_average_floor(&self, other: &$T) -> $T {
                 match self.checked_add(*other) {
-                    Some(z) => z.div_floor(&2),
+                    Some(z) => Integer::div_floor(&z, &2),
                     None => {
                         if self > other {
                             let diff = self - other;
-                            other + diff.div_floor(&2)
+                            other + Integer::div_floor(&diff, &2)
                         } else {
                             let diff = other - self;
-                            self + diff.div_floor(&2)
+                            self + Integer::div_floor(&diff, &2)
                         }
                     }
                 }
             }
             fn naive_average_ceil(&self, other: &$T) -> $T {
                 match self.checked_add(*other) {
-                    Some(z) => z.div_ceil(&2),
+                    Some(z) => Integer::div_ceil(&z, &2),
                     None => {
                         if self > other {
                             let diff = self - other;
-                            self - diff.div_floor(&2)
+                            self - Integer::div_floor(&diff, &2)
                         } else {
                             let diff = other - self;
-                            other - diff.div_floor(&2)
+                            other - Integer::div_floor(&diff, &2)
                         }
                     }
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -609,8 +609,9 @@ macro_rules! impl_integer_for_isize {
             fn test_div_mod_floor() {
                 fn test_nd_dm(nd: ($T, $T), dm: ($T, $T)) {
                     let (n, d) = nd;
-                    let separate_div_mod_floor = (n.div_floor(&d), n.mod_floor(&d));
-                    let combined_div_mod_floor = n.div_mod_floor(&d);
+                    let separate_div_mod_floor =
+                        (Integer::div_floor(&n, &d), Integer::mod_floor(&n, &d));
+                    let combined_div_mod_floor = Integer::div_mod_floor(&n, &d);
 
                     assert_eq!(separate_div_mod_floor, dm);
                     assert_eq!(combined_div_mod_floor, dm);
@@ -913,15 +914,16 @@ macro_rules! impl_integer_for_usize {
 
             #[test]
             fn test_div_mod_floor() {
-                assert_eq!((10 as $T).div_floor(&(3 as $T)), 3 as $T);
-                assert_eq!((10 as $T).mod_floor(&(3 as $T)), 1 as $T);
-                assert_eq!((10 as $T).div_mod_floor(&(3 as $T)), (3 as $T, 1 as $T));
-                assert_eq!((5 as $T).div_floor(&(5 as $T)), 1 as $T);
-                assert_eq!((5 as $T).mod_floor(&(5 as $T)), 0 as $T);
-                assert_eq!((5 as $T).div_mod_floor(&(5 as $T)), (1 as $T, 0 as $T));
-                assert_eq!((3 as $T).div_floor(&(7 as $T)), 0 as $T);
-                assert_eq!((3 as $T).mod_floor(&(7 as $T)), 3 as $T);
-                assert_eq!((3 as $T).div_mod_floor(&(7 as $T)), (0 as $T, 3 as $T));
+                assert_eq!(<$T as Integer>::div_floor(&10, &3), 3 as $T);
+                assert_eq!(<$T as Integer>::mod_floor(&10, &3), 1 as $T);
+                assert_eq!(<$T as Integer>::div_mod_floor(&10, &3), (3 as $T, 1 as $T));
+                assert_eq!(<$T as Integer>::div_floor(&5, &5), 1 as $T);
+                assert_eq!(<$T as Integer>::mod_floor(&5, &5), 0 as $T);
+                assert_eq!(<$T as Integer>::div_mod_floor(&5, &5), (1 as $T, 0 as $T));
+                assert_eq!(<$T as Integer>::div_floor(&3, &7), 0 as $T);
+                assert_eq!(<$T as Integer>::div_floor(&3, &7), 0 as $T);
+                assert_eq!(<$T as Integer>::mod_floor(&3, &7), 3 as $T);
+                assert_eq!(<$T as Integer>::div_mod_floor(&3, &7), (0 as $T, 3 as $T));
             }
 
             #[test]


### PR DESCRIPTION
This avoids the unstable inherent methods of rust#88581 by explicitly calling the trait methods.

Only tests were affected here, so there's no urgency to publish an update for `num-integer` dependents.