### PR TITLE
test_is_multiple_of: call is_multiple_of from trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1018,14 +1018,14 @@ macro_rules! impl_integer_for_usize {
 
             #[test]
             fn test_is_multiple_of() {
-                assert!((0 as $T).is_multiple_of(&(0 as $T)));
-                assert!((6 as $T).is_multiple_of(&(6 as $T)));
-                assert!((6 as $T).is_multiple_of(&(3 as $T)));
-                assert!((6 as $T).is_multiple_of(&(1 as $T)));
+                assert!(<$T as Integer>::is_multiple_of(&(0 as $T), &(0 as $T)));
+                assert!(<$T as Integer>::is_multiple_of(&(6 as $T), &(6 as $T)));
+                assert!(<$T as Integer>::is_multiple_of(&(6 as $T), &(3 as $T)));
+                assert!(<$T as Integer>::is_multiple_of(&(6 as $T), &(1 as $T)));
 
-                assert!(!(42 as $T).is_multiple_of(&(5 as $T)));
-                assert!(!(5 as $T).is_multiple_of(&(3 as $T)));
-                assert!(!(42 as $T).is_multiple_of(&(0 as $T)));
+                assert!(!<$T as Integer>::is_multiple_of(&(42 as $T), &(5 as $T)));
+                assert!(!<$T as Integer>::is_multiple_of(&(5 as $T), &(3 as $T)));
+                assert!(!<$T as Integer>::is_multiple_of(&(42 as $T), &(0 as $T)));
             }
 
             #[test]


### PR DESCRIPTION
is_multiple_of was just stabilized for unsigned integer types[0], so this fails to compile on recent nightlies without this fix.

0: https://github.com/rust-lang/rust/pull/137383